### PR TITLE
Per epoch sft

### DIFF
--- a/sc-locked-asset-factory/src/cache.rs
+++ b/sc-locked-asset-factory/src/cache.rs
@@ -1,0 +1,85 @@
+#![allow(non_snake_case)]
+
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+type Nonce = u64;
+type Epoch = u64;
+
+use distrib_common::*;
+
+const AMOUNT_TO_BURN: u64 = 1;
+const GAS_LEFT_THRESHOLD: u64 = 5000000;
+const BURN_TOKENS_GAS_LIMIT: u64 = 5000000;
+
+#[elrond_wasm_derive::module]
+pub trait CacheModule {
+    fn get_cached_sft_nonce_for_attributes(
+        &self,
+        attributes: &LockedTokenAttributes,
+    ) -> Option<Nonce> {
+        let current_epoch = self.blockchain().get_block_epoch();
+        let cache_epoch = self.cache_epoch().get();
+
+        if current_epoch != cache_epoch {
+            self.cache_epoch().set(&current_epoch);
+            self.cached_attributes_to_sft_nonce_map().clear();
+            None
+        } else {
+            self.cached_attributes_to_sft_nonce_map().get(attributes)
+        }
+    }
+
+    fn cache_attributes_and_nonce(&self, attributes: LockedTokenAttributes, nonce: Nonce) {
+        if self.cached_attributes_to_sft_nonce_map().is_empty() {
+            self.first_cached_sft_nonce().set(&nonce);
+        }
+
+        self.cached_attributes_to_sft_nonce_map()
+            .insert(attributes, nonce);
+    }
+
+    #[endpoint(cleanupUnusedTokens)]
+    fn cleanup_unused_tokens(&self, locked_asset_token_id: TokenIdentifier) -> SCResult<u64> {
+        only_owner!(self, "Permission denied");
+        let last_burned_sft_nonce_initial = self.last_burned_sft_nonce().get();
+        let first_cached_sft_nonce = self.first_cached_sft_nonce().get();
+        let mut last_burned_sft_nonce = last_burned_sft_nonce_initial;
+        let amount_to_burn = Self::BigUint::from(AMOUNT_TO_BURN);
+
+        for nonce in last_burned_sft_nonce + 1..first_cached_sft_nonce {
+            let gas_left = self.blockchain().get_gas_left();
+
+            if gas_left < GAS_LEFT_THRESHOLD {
+                break;
+            }
+            self.send().esdt_nft_burn(
+                BURN_TOKENS_GAS_LIMIT,
+                locked_asset_token_id.as_esdt_identifier(),
+                nonce,
+                &amount_to_burn,
+            );
+            last_burned_sft_nonce = nonce;
+        }
+
+        if last_burned_sft_nonce != last_burned_sft_nonce_initial {
+            self.last_burned_sft_nonce().set(&last_burned_sft_nonce);
+        }
+
+        Ok(last_burned_sft_nonce - last_burned_sft_nonce_initial)
+    }
+
+    #[storage_mapper("cached_attributes_to_sft_nonce_map")]
+    fn cached_attributes_to_sft_nonce_map(
+        &self,
+    ) -> MapMapper<Self::Storage, LockedTokenAttributes, Nonce>;
+
+    #[storage_mapper("cache_epoch")]
+    fn cache_epoch(&self) -> SingleValueMapper<Self::Storage, Epoch>;
+
+    #[storage_mapper("last_burned_sft_nonce")]
+    fn last_burned_sft_nonce(&self) -> SingleValueMapper<Self::Storage, Nonce>;
+
+    #[storage_mapper("first_cached_sft_nonce")]
+    fn first_cached_sft_nonce(&self) -> SingleValueMapper<Self::Storage, Nonce>;
+}

--- a/sc-locked-asset-factory/src/locked_asset.rs
+++ b/sc-locked-asset-factory/src/locked_asset.rs
@@ -111,13 +111,15 @@ pub trait LockedAssetModule: asset::AssetModule {
         let caller = self.blockchain().get_caller();
         self.mint_and_send_assets(&caller, &unlock_amount);
 
-        let new_unlock_milestones =
-            self.create_new_unlock_milestones(current_block_epoch, &attributes.unlock_milestones);
         let locked_remaining = amount.clone() - unlock_amount;
-        let attributes = LockedTokenAttributes {
-            unlock_milestones: new_unlock_milestones,
-        };
-        self.create_and_send_locked_assets(&locked_remaining, &attributes, &caller);
+        if locked_remaining > 0 {
+            let new_unlock_milestones =
+                self.create_new_unlock_milestones(current_block_epoch, &attributes.unlock_milestones);
+            let attributes = LockedTokenAttributes {
+                unlock_milestones: new_unlock_milestones,
+            };
+            self.create_and_send_locked_assets(&locked_remaining, &attributes, &caller);
+        }
 
         self.send()
             .burn_tokens(&token_id, token_nonce, &amount, BURN_TOKENS_GAS_LIMIT);


### PR DESCRIPTION
The purpose of this cache is not to create a new sft on every request. The idea is that when a new request arrives with a setup for attributes that was already created, just add quantity instead of create a new nonce. Also added a method for cleanup.